### PR TITLE
Change comment for PyList on gui exercise

### DIFF
--- a/src/exercises/gui/draw.py
+++ b/src/exercises/gui/draw.py
@@ -94,7 +94,6 @@ class PenDownCommand:
         return "<Command>PenDown</Command>"
 
 
-
 # This is the container class for a graphics sequence. It is meant
 # to hold the graphics commands sequence. 
 class PyList:

--- a/src/exercises/gui/draw.py
+++ b/src/exercises/gui/draw.py
@@ -94,7 +94,9 @@ class PenDownCommand:
         return "<Command>PenDown</Command>"
 
 
-# This is the PyList container object. It is meant to hold a
+
+# This is the container class for a graphics sequence. It is meant
+# to hold the graphics commands sequence. 
 class PyList:
     def __init__(self):
         self.gcList = []


### PR DESCRIPTION
It looks like part of the comment for PyList was cut off. I replaced that with the comment from here: http://jupyter.luther.edu/~leekent/CS2Plus/chap1/chap1.html